### PR TITLE
Ensure Attacker and Target are owned by Player in 'Attacked' Event Wrapper

### DIFF
--- a/source/simulation/ai/hannibal/events.js
+++ b/source/simulation/ai/hannibal/events.js
@@ -474,8 +474,8 @@ HANNIBAL = (function(H){
       // this.deb("   EVT: got attacked: %s", uneval(e));
 
       if (
-        (ents[e.target] || ents[e.attacker]) && 
-        (ents[e.target].owner() === this.id || ents[e.attacker].owner() === this.id)
+        ents[e.target] && ents[e.target].owner() === this.id
+        || ents[e.attacker] && ents[e.attacker].owner() === this.id
         ){
 
         this.fire("EntityAttacked", {


### PR DESCRIPTION
`(ents[e.target] || ents[e.attacker])`
evaluates to true if one of both is defined. Let's assume `ents[e.target]` is defined.
The righthand side of the `and` condition is evaluated.
`(ents[e.target].owner() === this.id || ents[e.attacker].owner() === this.id)`
Assumed the owner of e.target is != this.id, then the `or` is evaluated and can throw an error because the e.attacker being defined in ents has not been checked before.

Where compilers are involved this depends on the compiler. Some compiler might even evaluate the right side of the first `(ents[e.target] || ents[e.attacker])` even when the left side is already true.

This is javascript where you are the master, so I do not know if there are such exceptions in javascript interpreters or whatever too. SpiderMonkey VM at least did throw that error at me.

(As a bonus we get rid of some brackets.)

Agent, are you interested in the group interaction thingy, should I post a pull request? I am not sure if it fits into your concept|plan. (I will post a video trying to show the different behaviour.)